### PR TITLE
Update extension.js

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -16,7 +16,8 @@ const Cinnamon = imports.gi.Cinnamon;
 const WindowManager = imports.ui.windowManager;
 const MessageTray = imports.ui.messageTray;
 const Lang = imports.lang;
-const PanelMenu = imports.ui.panel;
+/*panelMenu.js has been removed in Cinnamon 1.8.x*/
+/*const PanelMenu = imports.ui.panelMenu;*/
 const DND = imports.ui.dnd;
 const Meta = imports.gi.Meta;
 const Clutter = imports.gi.Clutter;


### PR DESCRIPTION
Modification for making work on Cinnamon 1.8.0.
panelMenu.js seems to do not exist anymore in Cinnamon 1.8.0 and replaced by panel.js (checked on Cinnamon git repository).

const PanelMenu = imports.ui.panelMenu;
replaced by : 
const PanelMenu = imports.ui.panel;
